### PR TITLE
Assign requirements based on pip3

### DIFF
--- a/docker/requirements-l4t.txt
+++ b/docker/requirements-l4t.txt
@@ -21,10 +21,9 @@ requests==2.32.3
 scikit-image==0.19.3
 scikit-learn==1.6.1
 scipy==1.15.2
+seaborn==0.13.2
 setuptools==69.1.0
 shapely==1.8.2
 six==1.16.0
 tqdm==4.64.0
 transformers==4.51.3
-
-seaborn>=0.7.1

--- a/docker/requirements-l4t.txt
+++ b/docker/requirements-l4t.txt
@@ -1,28 +1,30 @@
-setuptools==69.1.0
-absl-py>=0.7.1
-matplotlib>=3.0.3
+absl-py==2.2.2
 h5py==3.7.0
-Pillow>=8.1.0,<9.0.0 # TF1 compatible
-pyrr==0.10.3
-PyYAML>=5.1
-six>=1.12.0
-pynvml==11.0.0
-mpi4py>=3.0.3
-pycocotools==2.0.7
 hydra-core==1.2.0 # DD compatible
-omegaconf==2.2.2 # DD compatible
-opencv-python>=4.8.0.76
-scikit-image>=0.17.2
-scikit-learn>=0.24.2
-scipy>=1.5.4
-seaborn==0.7.1
-onnx>=1.13.1
-onnxruntime>=1.13.1
-protobuf==3.20.2
-pyclipper>=1.1.0.post3
-numpy<=2.0
-shapely==1.8.2
+matplotlib==3.10.1
+mpi4py==4.0.3
 natsort==8.4.0
+numpy==1.26.4
+omegaconf==2.2.2 # DD compatible
+onnx==1.17.0
+onnxruntime==1.21.0
+opencv-python==4.11.0
+Pillow==8.4.0
+protobuf==3.20.2
+pyclipper==1.3.0.post6
+pycocotools==2.0.7
+pycuda==2024.1.2
+pynvml==11.0.0
+pyrr==0.10.3
+PyYAML==5.4.1
+requests==2.32.3
+scikit-image==0.19.3
+scikit-learn==1.6.1
+scipy==1.15.2
+setuptools==69.1.0
+shapely==1.8.2
+six==1.16.0
 tqdm==4.64.0
-requests>=2.31.0
-transformers>=4.38.2
+transformers==4.51.3
+
+seaborn>=0.7.1

--- a/docker/requirements-l4t.txt
+++ b/docker/requirements-l4t.txt
@@ -2,13 +2,13 @@ absl-py==2.2.2
 h5py==3.7.0
 hydra-core==1.2.0 # DD compatible
 matplotlib==3.10.1
-mpi4py==4.0.3
+# mpi4py==4.0.3
 natsort==8.4.0
 numpy==1.26.4
 omegaconf==2.2.2 # DD compatible
 onnx==1.17.0
 onnxruntime==1.21.0
-opencv-python==4.11.0
+# opencv-python==4.11.0
 Pillow==8.4.0
 protobuf==3.20.2
 pyclipper==1.3.0.post6

--- a/docker/requirements-l4t.txt
+++ b/docker/requirements-l4t.txt
@@ -11,19 +11,18 @@ mpi4py>=3.0.3
 pycocotools==2.0.7
 hydra-core==1.2.0 # DD compatible
 omegaconf==2.2.2 # DD compatible
-opencv-python==4.8.0.76
-scikit-image==0.17.2
-scikit-learn==0.24.2
-scipy==1.5.4
+opencv-python>=4.8.0.76
+scikit-image>=0.17.2
+scikit-learn>=0.24.2
+scipy>=1.5.4
 seaborn==0.7.1
 onnx>=1.13.1
 onnxruntime>=1.13.1
 protobuf==3.20.2
-pyclipper==1.1.0.post3
-numpy<=1.23.1
+pyclipper>=1.1.0.post3
+numpy<=2.0
 shapely==1.8.2
 natsort==8.4.0
 tqdm==4.64.0
 requests>=2.31.0
 transformers>=4.38.2
-git+https://github.com/cocodataset/panopticapi.git

--- a/nvidia_tao_deploy/cv/common/logging/status_logging.py
+++ b/nvidia_tao_deploy/cv/common/logging/status_logging.py
@@ -14,14 +14,14 @@
 
 """Logger class for TAO Deploy models."""
 
-from abc import abstractmethod
 import atexit
-from datetime import datetime
 import json
 import logging
 import os
+from abc import abstractmethod
+from datetime import datetime
 
-from nvidia_tao_core.cloud_handlers.utils import status_callback
+# from nvidia_tao_core.cloud_handlers.utils import status_callback
 
 
 logger = logging.getLogger(__name__)
@@ -179,7 +179,7 @@ class BaseLogger(object):
             if self.is_master:
                 self.log(verbosity_level, data_string)
             self.flush()
-            status_callback(data_string)
+            # status_callback(data_string)
 
 
 class StatusLogger(BaseLogger):


### PR DESCRIPTION
Update `requirements-l4t.txt` to install every package with a wheel - currently only works with `pip3 install -r tao_deploy/docker/requirements-l4t.txt` still... running `setup_l4t.py develop` after still accepts the installs, so this should be fine.

Removed `mpi4py` and `opencv-python` requirements as the former builds from source and takes 6-7 minutes per build, while the latter is overwritten by `apt install python3-opencv` anyways.

Also commented out `status_callback`, so that you can just run a given node.