### PR TITLE
Update grounding_dino and unet code to TRT 10

### DIFF
--- a/nvidia_tao_deploy/cv/grounding_dino/specs/infer.yaml
+++ b/nvidia_tao_deploy/cv/grounding_dino/specs/infer.yaml
@@ -1,20 +1,20 @@
-results_dir: /home/scratch.p3/sean/groundingdino/tao_integration/
+results_dir: /opt/fauna/data/test_imgs/out/
 dataset:
   infer_data_sources:
     image_dir: 
-      # - /home/projects2_metropolis/datasets/kpi_datasets/People/C0042_4.mp4/images_final_hres/
-      - /home/scratch.p3/sean/temp/
-    captions: ["dog", "cat"]
-  batch_size: 4
+      - /opt/fauna/data/test_imgs
+    captions: ["wallet", "keys", "ignore everything else"]
+  batch_size: 1
   workers: 8
 inference:
-  trt_engine: /home/scratch.p3/sean/groundingdino/tao_integration/swint2.engine
-  conf_threshold: 0.3
+  trt_engine: "/opt/fauna/cache/online_mapping/grounding_dino.engine"
+  conf_threshold: 0.1
   input_width: 960
   input_height: 544
   color_map:
-    "dog": green
-    "cat": red
+    "keys": red
+    "wallet": blue
+    "people": yellow
 model:
   backbone: swin_tiny_224_1k
   num_feature_levels: 4

--- a/nvidia_tao_deploy/cv/unet/dataloader.py
+++ b/nvidia_tao_deploy/cv/unet/dataloader.py
@@ -78,7 +78,7 @@ class UNetLoader(ABC):
         self.input_image_type = input_image_type
 
         # Always assume channel first
-        self.num_channels, self.height, self.width = shape[0], shape[1], shape[2]
+        self.num_channels, self.height, self.width = shape[1], shape[2], shape[3]
 
         if self.num_channels == 1 and self.input_image_type != "grayscale":
             raise ValueError("A network with channel size 1 expects grayscale input image type")


### PR DESCRIPTION
This updates the inference code for `grounding_dino` and `unet` to use `TensorRT` 10.0 API since that's the version we are using internally in our docker containers. 

For posterity, the engines for these models were generated like so - 

```
/usr/src/tensorrt/bin/trtexec--onnx=../models/grounding_dino_swin_tiny_commercial_trainable.onnx --optShapes=inputs:1x3x544x960,input_ids:1x256,attention_mask:1x256,position_ids:1x256,token_type_ids:1x256,text_token_mask:1x256x256 --fp16 --saveEngine=grounding_dino.engine
```

```
/usr/src/tensorrt/bin/trtexec --onnx=peoplesemsegnet_shuffleseg.onnx --optShapes=input_2:0:1x3x544x960 --saveEngine=model.engine
```